### PR TITLE
更新 Naive‐UI DatePickerProps

### DIFF
--- a/src/components/layout/topNav.vue
+++ b/src/components/layout/topNav.vue
@@ -29,37 +29,37 @@
             ref="menuRoot"
             class="relative"
           >
-          <img
-            :src="userAvatar"
-            @click="toggleMenu"
-            alt="avatar"
-            class="w-10 h-10 rounded-full object-cover cursor-pointer avatar"
-          />
+            <img
+              :src="userAvatar"
+              @click="toggleMenu"
+              alt="avatar"
+              class="w-10 h-10 rounded-full object-cover cursor-pointer avatar"
+            />
 
-          <!-- 下拉選單 -->
-          <ul
-            v-show="showMenu"
-            @click="showMenu = false"
-            class="absolute right-0 mt-2 w-48 bg-white text-black rounded shadow-lg overflow-hidden z-20"
-          >
-            <li
-              class="px-4 py-2 hover:bg-gray-100 cursor-pointer"
-              @click="go('/student/my-courses')"
-            >我的課程</li>
-            <li
-              class="px-4 py-2 hover:bg-gray-100 cursor-pointer"
-              @click="go('/home/student')"
-            >學生資料管理</li>
-            <li
-              class="px-4 py-2 hover:bg-gray-100 cursor-pointer"
-              @click="go('/student/orders')"
-            >訂單紀錄</li>
-            <li
-              class="px-4 py-2 hover:bg-gray-100 cursor-pointer"
-              @click="logout"
-            >登出</li>
-          </ul>
-        </div>
+            <!-- 下拉選單 -->
+            <ul
+              v-show="showMenu"
+              @click="showMenu = false"
+              class="absolute right-0 mt-2 w-48 bg-white text-black rounded shadow-lg overflow-hidden z-20"
+            >
+              <li
+                class="px-4 py-2 hover:bg-gray-100 cursor-pointer"
+                @click="go('/student/my-courses')"
+              >我的課程</li>
+              <li
+                class="px-4 py-2 hover:bg-gray-100 cursor-pointer"
+                @click="go('/home/student')"
+              >學生資料管理</li>
+              <li
+                class="px-4 py-2 hover:bg-gray-100 cursor-pointer"
+                @click="go('/student/orders')"
+              >訂單紀錄</li>
+              <li
+                class="px-4 py-2 hover:bg-gray-100 cursor-pointer"
+                @click="logout"
+              >登出</li>
+            </ul>
+          </div>
         </div>
       </nav>
     </div>

--- a/src/views/home/student/index.vue
+++ b/src/views/home/student/index.vue
@@ -49,7 +49,11 @@
 import { ref, onMounted } from 'vue';
 import axios from 'axios'
 import { useUserStore } from '@/stores/models/user/userStore'
-import { NButton, NForm, NFormItem, NInput, NSpace, NDatePicker, type DatePickerValue  } from 'naive-ui'
+import { NButton, NForm, NFormItem, NInput, NSpace, NDatePicker, datePickerProps  } from 'naive-ui'
+import type { ExtractPropTypes } from 'vue'
+type DatePickerProps = ExtractPropTypes<typeof datePickerProps>
+// 接著「挖出」裡面 value 的那個屬性，這就是 v-model:value 要的型別
+type DatePickerValue = DatePickerProps['value']
 interface StudentData {
   name: string
   birthday: DatePickerValue | null


### PR DESCRIPTION
在最新版本的 Naive‐UI 中，並沒有把 DatePickerProps 這個介面直接掛到套件根目錄上，所以才會看到
“naive-ui 沒有任何名稱為 'DatePickerProps' 的已匯出成員”

但其實 Naive‐UI 有把各元件的 props 定義暴露出來，例如日期選擇器就有一個 datePickerProps 物件，可以利用 Vue 的 ExtractPropTypes 來轉出它的 TypeScript 型別，然後再從裡面取出 value 的類型。

// 1. 從 naive-ui 拿到 datePickerProps
import { datePickerProps, NDatePicker, NButton, NForm, NFormItem, NInput, NSpace } from 'naive-ui'
// 2. 用 Vue 的 ExtractPropTypes 幫把 props 轉成 TS 型別
import type { ExtractPropTypes } from 'vue'

// 這一大段就是把 datePickerProps 轉成真正的 props 類型
type DatePickerProps = ExtractPropTypes<typeof datePickerProps>
// 接著「挖出」裡面 value 的那個屬性，這就是 v-model:value 要的型別
type DatePickerValue = DatePickerProps['value']